### PR TITLE
NODEID is needed for serial_upload too

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ NODE_ID:CMD
 
 ```
 $ cd node
-$ make serial_upload
+$ make NODEID=10 serial_upload
 ```
 
 #### Wireless


### PR DESCRIPTION
when u r using make for serial_upload, you have to set NODEID too, because NODEID statment is check before serial_upload definition
